### PR TITLE
Add support for async method calls

### DIFF
--- a/client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -1,0 +1,28 @@
+package io.avaje.http.client;
+
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+class DHttpAsync implements HttpAsyncResponse {
+
+  private final DHttpClientRequest request;
+
+  DHttpAsync(DHttpClientRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public CompletableFuture<HttpResponse<Void>> asDiscarding() {
+    return request
+      .performSendAsync(false, HttpResponse.BodyHandlers.discarding())
+      .thenApply(request::afterAsync);
+  }
+
+  @Override
+  public CompletableFuture<HttpResponse<String>> asString() {
+    return request
+      .performSendAsync(true, HttpResponse.BodyHandlers.ofString())
+      .thenApply(request::afterAsync);
+  }
+
+}

--- a/client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 class DHttpAsync implements HttpAsyncResponse {
@@ -30,5 +31,12 @@ class DHttpAsync implements HttpAsyncResponse {
     return request
       .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
       .thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<List<E>> list(Class<E> type) {
+    return request
+      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
+      .thenApply(httpResponse -> request.asyncList(type, httpResponse));
   }
 }

--- a/client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -25,4 +25,10 @@ class DHttpAsync implements HttpAsyncResponse {
       .thenApply(request::afterAsync);
   }
 
+  @Override
+  public <E> CompletableFuture<E> bean(Class<E> type) {
+    return request
+      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
+      .thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+  }
 }

--- a/client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -13,10 +13,15 @@ class DHttpAsync implements HttpAsyncResponse {
   }
 
   @Override
-  public CompletableFuture<HttpResponse<Void>> asDiscarding() {
+  public <E> CompletableFuture<HttpResponse<E>> withHandler(HttpResponse.BodyHandler<E>  handler) {
     return request
-      .performSendAsync(false, HttpResponse.BodyHandlers.discarding())
+      .performSendAsync(false, handler)
       .thenApply(request::afterAsync);
+  }
+
+  @Override
+  public CompletableFuture<HttpResponse<Void>> asDiscarding() {
+    return withHandler(HttpResponse.BodyHandlers.discarding());
   }
 
   @Override

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -100,7 +100,7 @@ class DHttpClientContext implements HttpClientContext {
     }
   }
 
-  void check(HttpResponse<byte[]> response) {
+  void checkMaybeThrow(HttpResponse<byte[]> response) {
     if (response.statusCode() >= 300) {
       throw new HttpException(this, response);
     }

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -9,6 +9,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 class DHttpClientContext implements HttpClientContext {
@@ -29,6 +30,7 @@ class DHttpClientContext implements HttpClientContext {
   private final boolean withAuthToken;
   private final AuthTokenProvider authTokenProvider;
   private final AtomicReference<AuthToken> tokenRef = new AtomicReference<>();
+  private int loggingMaxBody = 1_000;
 
   DHttpClientContext(HttpClient httpClient, String baseUrl, Duration requestTimeout, BodyAdapter bodyAdapter, RetryHandler retryHandler, RequestListener requestListener, AuthTokenProvider authTokenProvider, RequestIntercept intercept) {
     this.httpClient = httpClient;
@@ -155,6 +157,10 @@ class DHttpClientContext implements HttpClientContext {
     }
   }
 
+  <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest.Builder requestBuilder, HttpResponse.BodyHandler<T> bodyHandler) {
+    return httpClient.sendAsync(requestBuilder.build(), bodyHandler);
+  }
+
   BodyContent write(Object bean, String contentType) {
     return bodyAdapter.beanWriter(bean.getClass()).write(bean, contentType);
   }
@@ -198,4 +204,7 @@ class DHttpClientContext implements HttpClientContext {
     return authToken.token();
   }
 
+  String maxResponseBody(String body) {
+    return body.length() > loggingMaxBody ? body.substring(0, loggingMaxBody) + " <truncated> ..." : body;
+  }
 }

--- a/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -394,15 +394,24 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
   }
 
   protected <E> E asyncBean(Class<E> type, HttpResponse<byte[]> response) {
+    afterAsyncEncoded(response);
+    return context.readBean(type, encodedResponseBody);
+  }
+
+  protected <E> List<E> asyncList(Class<E> type, HttpResponse<byte[]> response) {
+    afterAsyncEncoded(response);
+    return context.readList(type, encodedResponseBody);
+  }
+
+  private void afterAsyncEncoded(HttpResponse<byte[]> response) {
     requestTimeNanos = System.nanoTime() - startAsyncNanos;
     httpResponse = response;
     encodedResponseBody = context.readContent(response);
     context.afterResponse(this);
     context.checkMaybeThrow(response);
-    return context.readBean(type, encodedResponseBody);
   }
 
-  public <E> HttpResponse<E> afterAsync(HttpResponse<E> response) {
+  protected <E> HttpResponse<E> afterAsync(HttpResponse<E> response) {
     requestTimeNanos = System.nanoTime() - startAsyncNanos;
     httpResponse = response;
     context.afterResponse(this);

--- a/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -357,7 +357,7 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
 
   @Override
   public <T> Stream<T> stream(Class<T> cls) {
-    final HttpResponse<Stream<String>> res = withResponseHandler(HttpResponse.BodyHandlers.ofLines());
+    final HttpResponse<Stream<String>> res = withHandler(HttpResponse.BodyHandlers.ofLines());
     this.httpResponse = res;
     if (res.statusCode() >= 300) {
       throw new HttpException(res, context);
@@ -367,7 +367,7 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
   }
 
   @Override
-  public <T> HttpResponse<T> withResponseHandler(HttpResponse.BodyHandler<T> responseHandler) {
+  public <T> HttpResponse<T> withHandler(HttpResponse.BodyHandler<T> responseHandler) {
     context.beforeRequest(this);
     addHeaders();
     HttpResponse<T> response = performSend(responseHandler);
@@ -420,33 +420,33 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
 
   @Override
   public HttpResponse<byte[]> asByteArray() {
-    return withResponseHandler(HttpResponse.BodyHandlers.ofByteArray());
+    return withHandler(HttpResponse.BodyHandlers.ofByteArray());
   }
 
   @Override
   public HttpResponse<String> asString() {
     loggableResponseBody = true;
-    return withResponseHandler(HttpResponse.BodyHandlers.ofString());
+    return withHandler(HttpResponse.BodyHandlers.ofString());
   }
 
   @Override
   public HttpResponse<Void> asDiscarding() {
-    return withResponseHandler(discarding());
+    return withHandler(discarding());
   }
 
   @Override
   public HttpResponse<InputStream> asInputStream() {
-    return withResponseHandler(HttpResponse.BodyHandlers.ofInputStream());
+    return withHandler(HttpResponse.BodyHandlers.ofInputStream());
   }
 
   @Override
   public HttpResponse<Path> asFile(Path file) {
-    return withResponseHandler(HttpResponse.BodyHandlers.ofFile(file));
+    return withHandler(HttpResponse.BodyHandlers.ofFile(file));
   }
 
   @Override
   public HttpResponse<Stream<String>> asLines() {
-    return withResponseHandler(HttpResponse.BodyHandlers.ofLines());
+    return withHandler(HttpResponse.BodyHandlers.ofLines());
   }
 
   private HttpRequest.Builder newReq(String url) {
@@ -564,7 +564,7 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
 
     private final HttpResponse<?> orig;
 
-    @SuppressWarnings({"unchecked", "raw"})
+    @SuppressWarnings({"raw"})
     HttpVoidResponse(HttpResponse<?> orig) {
       this.orig = orig;
     }

--- a/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -553,7 +553,8 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
       if (encodedResponseBody != null) {
         return context.maxResponseBody(new String(encodedResponseBody.content(), StandardCharsets.UTF_8));
       } else if (httpResponse != null && loggableResponseBody) {
-        return context.maxResponseBody(httpResponse.body().toString());
+        final Object body = httpResponse.body();
+        return (body == null) ? null : context.maxResponseBody(body.toString());
       }
       return null;
     }

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -1,0 +1,21 @@
+package io.avaje.http.client;
+
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Async responses as CompletableFuture.
+ */
+public interface HttpAsyncResponse {
+
+  /**
+   * Process discarding response body as {@literal HttpResponse<Void>}.
+   */
+  CompletableFuture<HttpResponse<Void>> asDiscarding();
+
+  /**
+   * Process as String response body {@literal HttpResponse<String>}.
+   */
+  CompletableFuture<HttpResponse<String>> asString();
+
+}

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -81,11 +82,37 @@ public interface HttpAsyncResponse {
    *           // use helloDto
    *           ...
    *         }
-   *
    *       });
-   *
-   *
    * }</pre>
    */
   <E> CompletableFuture<E> bean(Class<E> type);
+
+  /**
+   * Process expecting a list of beans response body (typically from json content).
+   * <p>
+   * If the HTTP statusCode is 300 or above a HttpException is throw which
+   * contains the HttpResponse.
+   *
+   * <pre>{@code
+   *
+   *    clientContext.request()
+   *       ...
+   *       .GET().async()
+   *       .list(HelloDto.class)
+   *       .whenComplete((helloDtos, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           HttpException httpException = (HttpException) throwable.getCause();
+   *           int statusCode = httpException.getStatusCode();
+   *           ...
+   *
+   *         } else {
+   *           // use list of helloDto
+   *           ...
+   *         }
+   *       });
+   * }</pre>
+   */
+  <E> CompletableFuture<List<E>> list(Class<E> type);
+
 }

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Async responses as CompletableFuture.
+ * Async processing of the request with responses as CompletableFuture.
  */
 public interface HttpAsyncResponse {
 
@@ -29,6 +29,8 @@ public interface HttpAsyncResponse {
    *       });
    *
    * }</pre>
+   *
+   * @return The CompletableFuture of the response
    */
   CompletableFuture<HttpResponse<Void>> asDiscarding();
 
@@ -53,8 +55,52 @@ public interface HttpAsyncResponse {
    *       });
    *
    * }</pre>
+   *
+   * @return The CompletableFuture of the response
    */
   CompletableFuture<HttpResponse<String>> asString();
+
+  /**
+   * Process with any given {@code HttpResponse.BodyHandler}.
+   *
+   * <h3>Example: line subscriber</h3>
+   * <p>
+   * Subscribe line by line to the response.
+   * </p>
+   * <pre>{@code
+   *
+   *    CompletableFuture<HttpResponse<Void>> future = clientContext.request()
+   *       .path("hello/lineStream")
+   *       .GET().async()
+   *       .withHandler(HttpResponse.BodyHandlers.fromLineSubscriber(new Flow.Subscriber<>() {
+   *
+   *         @Override
+   *         public void onSubscribe(Flow.Subscription subscription) {
+   *           subscription.request(Long.MAX_VALUE);
+   *         }
+   *         @Override
+   *         public void onNext(String item) {
+   *           ...
+   *         }
+   *         @Override
+   *         public void onError(Throwable throwable) {
+   *           ...
+   *         }
+   *         @Override
+   *         public void onComplete() {
+   *           ...
+   *         }
+   *       }))
+   *       .whenComplete((hres, throwable) -> {
+   *         int statusCode = hres.statusCode();
+   *         ...
+   *       });
+   * }</pre>
+   *
+   * @param bodyHandlers The body handler to use to process the response
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<HttpResponse<E>> withHandler(HttpResponse.BodyHandler<E> bodyHandlers);
 
   /**
    * Process expecting a bean response body (typically from json content).
@@ -84,6 +130,9 @@ public interface HttpAsyncResponse {
    *         }
    *       });
    * }</pre>
+   *
+   * @param type The bean type to convert the content to
+   * @return The CompletableFuture of the response
    */
   <E> CompletableFuture<E> bean(Class<E> type);
 
@@ -112,6 +161,9 @@ public interface HttpAsyncResponse {
    *         }
    *       });
    * }</pre>
+   *
+   * @param type The bean type to convert the content to
+   * @return The CompletableFuture of the response
    */
   <E> CompletableFuture<List<E>> list(Class<E> type);
 

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -10,16 +10,53 @@ public interface HttpAsyncResponse {
 
   /**
    * Process discarding response body as {@literal HttpResponse<Void>}.
+   *
+   * <pre>{@code
+   *
+   *   clientContext.request()
+   *       .path("hello/world")
+   *       .GET()
+   *       .async().asDiscarding()
+   *       .whenComplete((hres, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           ...
+   *         } else {
+   *           int statusCode = hres.statusCode();
+   *           ...
+   *         }
+   *       });
+   *
+   * }</pre>
    */
   CompletableFuture<HttpResponse<Void>> asDiscarding();
 
   /**
    * Process as String response body {@literal HttpResponse<String>}.
+   *
+   * <pre>{@code
+   *
+   *   clientContext.request()
+   *       .path("hello/world")
+   *       .GET()
+   *       .async().asString()
+   *       .whenComplete((hres, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           ...
+   *         } else {
+   *           int statusCode = hres.statusCode();
+   *           String body = hres.body();
+   *           ...
+   *         }
+   *       });
+   *
+   * }</pre>
    */
   CompletableFuture<HttpResponse<String>> asString();
 
   /**
-   * Process expecting a (json) bean response body.
+   * Process expecting a bean response body (typically from json content).
    * <p>
    * If the HTTP statusCode is 300 or above a HttpException is throw which
    * contains the HttpResponse.

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -18,4 +18,37 @@ public interface HttpAsyncResponse {
    */
   CompletableFuture<HttpResponse<String>> asString();
 
+  /**
+   * Process expecting a (json) bean response body.
+   * <p>
+   * If the HTTP statusCode is 300 or above a HttpException is throw which
+   * contains the HttpResponse.
+   *
+   * <pre>{@code
+   *
+   *    clientContext.request()
+   *       ...
+   *       .POST().async()
+   *       .bean(HelloDto.class)
+   *       .whenComplete((helloDto, throwable) -> {
+   *
+   *         if (throwable != null) {
+   *           HttpException httpException = (HttpException) throwable.getCause();
+   *           int statusCode = httpException.getStatusCode();
+   *
+   *           // maybe convert json error response body to a bean (using Jackson/Gson)
+   *           MyErrorBean errorResponse = httpException.bean(MyErrorBean.class);
+   *           ..
+   *
+   *         } else {
+   *           // use helloDto
+   *           ...
+   *         }
+   *
+   *       });
+   *
+   *
+   * }</pre>
+   */
+  <E> CompletableFuture<E> bean(Class<E> type);
 }

--- a/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -13,6 +13,11 @@ import java.util.stream.Stream;
 public interface HttpClientResponse {
 
   /**
+   * Send the request async using CompletableFuture.
+   */
+  HttpAsyncResponse async();
+
+  /**
    * Returning the response using the given response reader.
    *
    * @param reader The response reader.

--- a/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -108,6 +108,14 @@ public interface HttpClientResponse {
   /**
    * Return the response using the given response body handler.
    */
-  <T> HttpResponse<T> withResponseHandler(HttpResponse.BodyHandler<T> responseHandler);
+  <T> HttpResponse<T> withHandler(HttpResponse.BodyHandler<T> responseHandler);
+
+  /**
+   * Deprecated migrate to {@link #withHandler(HttpResponse.BodyHandler)}
+   */
+  @Deprecated
+  default <T> HttpResponse<T> withResponseHandler(HttpResponse.BodyHandler<T> responseHandler) {
+    return withHandler(responseHandler);
+  }
 
 }

--- a/client/src/main/java/io/avaje/http/client/HttpException.java
+++ b/client/src/main/java/io/avaje/http/client/HttpException.java
@@ -43,7 +43,7 @@ import java.nio.charset.StandardCharsets;
 public class HttpException extends RuntimeException {
 
   private final int statusCode;
-  private HttpClientContext context;
+  private DHttpClientContext context;
   private HttpResponse<?> httpResponse;
 
   /**
@@ -70,14 +70,14 @@ public class HttpException extends RuntimeException {
     this.statusCode = statusCode;
   }
 
-  HttpException(HttpResponse<?> httpResponse, HttpClientContext context) {
+  HttpException(HttpResponse<?> httpResponse, DHttpClientContext context) {
     super();
     this.httpResponse = httpResponse;
     this.statusCode = httpResponse.statusCode();
     this.context = context;
   }
 
-  HttpException(HttpClientContext context, HttpResponse<byte[]> httpResponse) {
+  HttpException(DHttpClientContext context, HttpResponse<byte[]> httpResponse) {
     super();
     this.httpResponse = httpResponse;
     this.statusCode = httpResponse.statusCode();
@@ -93,7 +93,7 @@ public class HttpException extends RuntimeException {
   @SuppressWarnings("unchecked")
   public <T> T bean(Class<T> cls) {
     final BodyContent body = context.readContent((HttpResponse<byte[]>) httpResponse);
-    return context.converters().beanReader(cls).read(body);
+    return context.readBean(cls, body);
   }
 
   /**

--- a/client/src/main/java/io/avaje/http/client/HttpException.java
+++ b/client/src/main/java/io/avaje/http/client/HttpException.java
@@ -8,7 +8,37 @@ import java.nio.charset.StandardCharsets;
  * <p>
  * Wraps an underlying HttpResponse with helper methods to get the response body
  * as string or as a bean.
- * </p>
+ *
+ * <h3>Example catching HttpException</h3>
+ * <pre>{@code
+ *
+ *   try {
+ *       clientContext.request()
+ *         .path("hello/saveForm")
+ *         .formParam("email", "user@foo.com")
+ *         .formParam("url", "notAValidUrl")
+ *         .POST()
+ *         .asVoid();
+ *
+ *     } catch (HttpException e) {
+ *
+ *       // obtain the statusCode from the exception ...
+ *       int statusCode = e.getStatusCode());
+ *
+ *       HttpResponse<?> httpResponse = e.getHttpResponse();
+ *
+ *       // obtain the statusCode from httpResponse ...
+ *       int statusCode = httpResponse.statusCode();
+ *
+ *       // convert error response body into a bean (typically Jackson/Gson)
+ *       final MyErrorBean errorResponse = e.bean(MyErrorBean.class);
+ *
+ *       final Map<String, String> errorMap = errorResponse.getErrors();
+ *       assertThat(errorMap.get("url")).isEqualTo("must be a valid URL");
+ *       assertThat(errorMap.get("name")).isEqualTo("must not be null");
+ *     }
+ *
+ * }</pre>
  */
 public class HttpException extends RuntimeException {
 

--- a/client/src/main/java/io/avaje/http/client/JacksonBodyAdapter.java
+++ b/client/src/main/java/io/avaje/http/client/JacksonBodyAdapter.java
@@ -93,9 +93,9 @@ public class JacksonBodyAdapter implements BodyAdapter {
     }
 
     @Override
-    public T read(BodyContent s) {
+    public T read(BodyContent bodyContent) {
       try {
-        return reader.readValue(s.content());
+        return reader.readValue(bodyContent.content());
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -52,12 +52,20 @@ class HelloControllerTest extends BaseWebTest {
   @Test
   void async_get_asString() throws ExecutionException, InterruptedException {
 
+    AtomicReference<HttpResponse<String>> ref = new AtomicReference<>();
+
     final CompletableFuture<HttpResponse<String>> future = clientContext.request()
       .path("hello").path("message")
       .GET()
-      .async().asString();
+      .async().asString()
+      .whenComplete((hres, throwable) -> {
+        ref.set(hres);
+        assertThat(hres.statusCode()).isEqualTo(200);
+        assertThat(hres.body()).contains("hello world");
+      });
 
     final HttpResponse<String> hres = future.get();
+    assertThat(hres).isSameAs(ref.get());
     assertThat(hres.body()).contains("hello world");
     assertThat(hres.statusCode()).isEqualTo(200);
   }

--- a/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -105,6 +105,27 @@ class HelloControllerTest extends BaseWebTest {
   }
 
   @Test
+  void async_list() throws ExecutionException, InterruptedException {
+
+    AtomicReference<List<HelloDto>> ref = new AtomicReference<>();
+
+    final CompletableFuture<List<HelloDto>> future = clientContext.request()
+      .path("hello")
+      .GET().async()
+      .list(HelloDto.class);
+
+    future.whenComplete((helloDtos, throwable) -> {
+      assertThat(throwable).isNull();
+      assertThat(helloDtos).hasSize(2);
+      ref.set(helloDtos);
+    });
+
+    final List<HelloDto> helloDtos = future.get();
+    assertThat(helloDtos).hasSize(2);
+    assertThat(helloDtos).isSameAs(ref.get());
+  }
+
+  @Test
   void get_withPathParamAndQueryParam_returningBean() {
 
     final HelloDto dto = clientContext.request()

--- a/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +43,31 @@ class HelloControllerTest extends BaseWebTest {
       .GET().asString();
 
     assertThat(hres.body()).contains("hello world");
+    assertThat(hres.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void async_get_asString() throws ExecutionException, InterruptedException {
+
+    final CompletableFuture<HttpResponse<String>> future = clientContext.request()
+      .path("hello").path("message")
+      .GET()
+      .async().asString();
+
+    final HttpResponse<String> hres = future.get();
+    assertThat(hres.body()).contains("hello world");
+    assertThat(hres.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void async_get_asDiscarding() throws ExecutionException, InterruptedException {
+
+    final CompletableFuture<HttpResponse<Void>> future = clientContext.request()
+      .path("hello").path("message")
+      .GET()
+      .async().asDiscarding();
+
+    final HttpResponse<Void> hres = future.get();
     assertThat(hres.statusCode()).isEqualTo(200);
   }
 

--- a/client/src/test/java/org/example/github/GithubTest.java
+++ b/client/src/test/java/org/example/github/GithubTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.avaje.http.client.HttpClientContext;
 import io.avaje.http.client.JacksonBodyAdapter;
+import io.avaje.http.client.RequestLogger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -18,11 +19,26 @@ public class GithubTest {
 
   @Test
   @Disabled
-  void test() {
+  void test() throws InterruptedException {
+
     final HttpClientContext clientContext = HttpClientContext.newBuilder()
       .withBaseUrl("https://api.github.com")
       .withBodyAdapter(bodyAdapter)
+      .withRequestListener(new RequestLogger())
       .build();
+
+    clientContext.request()
+      .path("users").path("rbygrave").path("repos")
+      .GET()
+      .async()
+      .asString()
+      .thenAccept(res -> {
+
+        System.out.println("RES: "+res.statusCode());
+        System.out.println("BODY: "+res.body());
+      });
+
+    Thread.sleep(1_000);
 
     // will not work under module classpath without registering the HttpApiProvider
     final Simple simple = clientContext.create(Simple.class);


### PR DESCRIPTION
## .async().asDiscarding()

```java

clientContext.request()
   .path("hello/world")
   .GET()
   .async().asDiscarding()
   .whenComplete((hres, throwable) -> {

     if (throwable != null) {
       ...
     } else {
       int statusCode = hres.statusCode();
       ...
     }
   });

```

##  .async().asString()

```java
clientContext.request()
   .path("hello/world")
   .GET()
   .async().asString()
   .whenComplete((hres, throwable) -> {

     if (throwable != null) {
       ...
     } else {
       int statusCode = hres.statusCode();
       String body = hres.body();
       ...
     }
   });
```

## .async().bean(HelloDto.class)

```java
clientContext.request()
   ...
   .POST().async()
   .bean(HelloDto.class)
   .whenComplete((helloDto, throwable) -> {

     if (throwable != null) {
       HttpException httpException = (HttpException) throwable.getCause();
       int statusCode = httpException.getStatusCode();

       // maybe convert json error response body to a bean (using Jackson/Gson)
       MyErrorBean errorResponse = httpException.bean(MyErrorBean.class);
       ..

     } else {
       // use helloDto
       ...
     }
   });

```

## .async().withHandler(...)

```java
CompletableFuture<HttpResponse<Void>> future = clientContext.request()
   .path("hello/lineStream")
   .GET().async()
   .withHandler(HttpResponse.BodyHandlers.fromLineSubscriber(new Flow.Subscriber<>() {

     @Override
     public void onSubscribe(Flow.Subscription subscription) {
       subscription.request(Long.MAX_VALUE);
     }
     @Override
     public void onNext(String item) {
       ...
     }
     @Override
     public void onError(Throwable throwable) {
       ...
     }
     @Override
     public void onComplete() {
       ...
     }
   }))
   .whenComplete((hres, throwable) -> {
     int statusCode = hres.statusCode();
     ...
   });

```
