### PR TITLE
Change such that Executor is used by default with async whenComplete

### DIFF
--- a/client/src/main/java/io/avaje/http/client/DHttpClientContextBuilder.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContextBuilder.java
@@ -159,7 +159,7 @@ class DHttpClientContextBuilder implements HttpClientContext.Builder {
       // register the built in request/response logging
       requestListener(new RequestLogger());
     }
-    return new DHttpClientContext(client, baseUrl, requestTimeout, bodyAdapter, retryHandler, buildListener(), authTokenProvider, buildIntercept());
+    return new DHttpClientContext(client, baseUrl, requestTimeout, bodyAdapter, retryHandler, buildListener(), authTokenProvider, buildIntercept(), executor);
   }
 
   private RequestListener buildListener() {

--- a/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientRequest.java
@@ -50,7 +50,7 @@ class DHttpClientRequest implements HttpClientRequest, HttpClientResponse {
   private boolean loggableResponseBody;
   private boolean skipAuthToken;
   private boolean suppressLogging;
-  private long startAsyncNanos;
+  protected long startAsyncNanos;
   private String label;
   private Map<String, Object> customAttributes;
 

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -9,6 +9,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The HTTP client context that we use to build and process requests.
@@ -114,6 +115,19 @@ public interface HttpClientContext {
    * @return The decoded content
    */
   byte[] decodeContent(String encoding, byte[] content);
+
+  /**
+   * When this context is created with an Executor and that is an ExecutorService
+   * then this will wait for async requests to be processed and then shutdown the
+   * ExecutorService.
+   *
+   * @param timeout  The maximum time to wait for async processes to complete
+   * @param timeUnit The time unit for maximum wait time
+   * @return True when successfully waited for async requests and shutdown
+   *
+   * @see HttpClientContext.Builder#executor(Executor)
+   */
+  boolean shutdown(long timeout, TimeUnit timeUnit);
 
   /**
    * Builds the HttpClientContext.

--- a/client/src/test/java/io/avaje/http/client/AsyncExecutorTest.java
+++ b/client/src/test/java/io/avaje/http/client/AsyncExecutorTest.java
@@ -1,0 +1,59 @@
+package io.avaje.http.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AsyncExecutorTest extends BaseWebTest {
+
+  final Logger log = LoggerFactory.getLogger(AsyncExecutorTest.class);
+
+  @Test
+  void context_shutdown() {
+
+    final HttpClientContext clientContext = HttpClientContext.newBuilder()
+      .baseUrl(baseUrl)
+      .bodyAdapter(new JacksonBodyAdapter(new ObjectMapper()))
+      .executor(Executors.newSingleThreadExecutor())
+      .build();
+
+    final CompletableFuture<HttpResponse<Stream<String>>> future = clientContext.request()
+      .path("hello").path("stream")
+      .GET()
+      .async()
+      .asLines();
+
+    final AtomicReference<String> threadName = new AtomicReference<>();
+    final AtomicBoolean flag = new AtomicBoolean();
+    future.whenComplete((hres, throwable) -> {
+      flag.set(true);
+      threadName.set(Thread.currentThread().getName());
+      log.info("processing response");
+      LockSupport.parkNanos(600_000_000);
+      assertThat(hres.statusCode()).isEqualTo(200);
+      List<String> lines = hres.body().collect(Collectors.toList());
+      assertThat(lines).hasSize(4);
+      assertThat(lines.get(0)).contains("{\"id\":1, \"name\":\"one\"}");
+      log.info("processing response complete");
+    });
+
+    assertThat(flag).isFalse(); // haven't run the async process yet
+    assertThat(clientContext.shutdown(2, TimeUnit.SECONDS)).isTrue();
+    assertThat(flag).isTrue();
+    assertThat(threadName.get()).endsWith("-thread-1");
+  }
+
+}
+

--- a/client/src/test/java/io/avaje/http/client/DHttpClientContextTest.java
+++ b/client/src/test/java/io/avaje/http/client/DHttpClientContextTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DHttpClientContextTest {
 
-  private final DHttpClientContext context = new DHttpClientContext(null, null, null, null, null, null, null, null);
+  private final DHttpClientContext context = new DHttpClientContext(null, null, null, null, null, null, null, null, null);
 
   @Test
   void create() {


### PR DESCRIPTION
Refer
-    https://bugs.openjdk.java.net/browse/JDK-8204339 - HTTP Client Dependent tasks should run in the common pool
-    https://bugs.openjdk.java.net/browse/JDK-8204679 - HTTP Client refresh
-    https://bugs.openjdk.java.net/browse/JDK-8209943 - HttpClient.Builder::executor minor spec correction for dependent tasks
-    https://stackoverflow.com/questions/51907641/java-11-http-client-asynchronous-execution

This PR changes avaje-http-client such that when an `Executor` is provided then async will by default use that given Executor rather than the `ForkJoinPool.commonPool()`.

At this stage I'm not 100% sure if we should merge this change.