### PR TITLE
Add retry exception handler

### DIFF
--- a/client/src/main/java/io/avaje/http/client/HttpException.java
+++ b/client/src/main/java/io/avaje/http/client/HttpException.java
@@ -91,28 +91,37 @@ public class HttpException extends RuntimeException {
   }
 
   /**
-   * Return the response body content as a bean
+   * Return the response body content as a bean, or else null if body content doesn't exist.
    *
    * @param cls The type of bean to convert the response to
    * @return The response as a bean
    */
   public <T> T bean(Class<T> cls) {
+    if (httpResponse == null) {
+      return null;
+    }
     final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
     return context.readBean(cls, body);
   }
 
   /**
-   * Return the response body content as a UTF8 string.
+   * Return the response body content as a UTF8 string, or else null if body content doesn't exist.
    */
   public String bodyAsString() {
+    if (httpResponse == null) {
+      return null;
+    }
     final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
     return new String(body.content(), StandardCharsets.UTF_8);
   }
 
-  /**
-   * Return the response body content as raw bytes.
+  /** 
+   * Return the response body content as raw bytes, or else null if body content doesn't exist.
    */
   public byte[] bodyAsBytes() {
+    if (httpResponse == null) {
+      return null;
+    }
     final BodyContent body = context.readErrorContent(responseAsBytes, httpResponse);
     return body.content();
   }

--- a/client/src/main/java/io/avaje/http/client/RetryHandler.java
+++ b/client/src/main/java/io/avaje/http/client/RetryHandler.java
@@ -11,9 +11,19 @@ public interface RetryHandler {
    * Return true if the request should be retried.
    *
    * @param retryCount The number of retry attempts already executed
-   * @param response   The HTTP response
+   * @param response The HTTP response
    * @return True if the request should be retried or false if not
    */
   boolean isRetry(int retryCount, HttpResponse<?> response);
 
+  /**
+   * Return true if the request should be retried.
+   *
+   * @param retryCount The number of retry attempts already executed
+   * @param exception The Wrapped Error thrown by the underlying Http Client
+   * @return True if the request should be retried or false if not
+   */
+  default boolean isExceptionRetry(int retryCount, HttpException exception) {
+    throw exception;
+  }
 }


### PR DESCRIPTION
- Add a new default method to the RetryHandler Interface
- use a do while block so exceptions can be retried
- HttpException returns null for the body retrieving methods instead of throwing a NullPointerException.

Takes care of #53