### PR TITLE
Add support for Jsonb generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ public final class ExampleRetry implements RetryHandler {
 
     final var code = response.statusCode();
 
-    if (retryCount >= MAX_RETRIES || code >= 400) {
+    if (retryCount >= MAX_RETRIES || code <= 400) {
 
       return false;
     }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -39,14 +39,14 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>1.0-RC1</version>
+      <version>1.1-RC2</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>8.6</version>
+      <version>8.10</version>
       <optional>true</optional>
     </dependency>
 
@@ -76,14 +76,14 @@
     <dependency>
       <groupId>io.javalin</groupId>
       <artifactId>javalin</artifactId>
-      <version>4.1.1</version>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-api</artifactId>
-      <version>1.16</version>
+      <version>1.20</version>
       <scope>test</scope>
     </dependency>
 
@@ -125,7 +125,7 @@
                 <path>
                   <groupId>io.avaje</groupId>
                   <artifactId>avaje-inject-generator</artifactId>
-                  <version>8.6</version>
+                  <version>8.10</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>

--- a/client/src/main/java/io/avaje/http/client/BodyAdapter.java
+++ b/client/src/main/java/io/avaje/http/client/BodyAdapter.java
@@ -1,5 +1,6 @@
 package io.avaje.http.client;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
 
 /**
@@ -24,10 +25,28 @@ public interface BodyAdapter {
   <T> BodyReader<T> beanReader(Class<T> type);
 
   /**
+   * Return a BodyReader to read response content and convert to a bean.
+   *
+   * @param type The bean type to convert the content to.
+   */
+  default <T> BodyReader<T> beanReader(ParameterizedType type) {
+    throw new UnsupportedOperationException("Parameterized types not supported for this adapter");
+  }
+
+
+  /**
    * Return a BodyReader to read response content and convert to a list of beans.
    *
    * @param type The bean type to convert the content to.
    */
   <T> BodyReader<List<T>> listReader(Class<T> type);
 
+  /**
+   * Return a BodyReader to read response content and convert to a list of beans.
+   *
+   * @param type The bean type to convert the content to.
+   */
+  default <T> BodyReader<List<T>> listReader(ParameterizedType type) {
+    throw new UnsupportedOperationException("Parameterized types not supported for this adapter");
+  }
 }

--- a/client/src/main/java/io/avaje/http/client/BodyAdapter.java
+++ b/client/src/main/java/io/avaje/http/client/BodyAdapter.java
@@ -47,6 +47,6 @@ public interface BodyAdapter {
    * @param type The bean type to convert the content to.
    */
   default <T> BodyReader<List<T>> listReader(ParameterizedType type) {
-    throw new UnsupportedOperationException("Parameterized types not supported for this Body Adapter");
+    throw new UnsupportedOperationException("Parameterized types not supported for this adapter");
   }
 }

--- a/client/src/main/java/io/avaje/http/client/BodyAdapter.java
+++ b/client/src/main/java/io/avaje/http/client/BodyAdapter.java
@@ -47,6 +47,6 @@ public interface BodyAdapter {
    * @param type The bean type to convert the content to.
    */
   default <T> BodyReader<List<T>> listReader(ParameterizedType type) {
-    throw new UnsupportedOperationException("Parameterized types not supported for this adapter");
+    throw new UnsupportedOperationException("Parameterized types not supported for this Body Adapter");
   }
 }

--- a/client/src/main/java/io/avaje/http/client/DHttpAsync.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpAsync.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -74,6 +75,27 @@ final class DHttpAsync implements HttpAsyncResponse {
 
   @Override
   public <E> CompletableFuture<Stream<E>> stream(Class<E> type) {
+    return request
+      .performSendAsync(false, HttpResponse.BodyHandlers.ofLines())
+      .thenApply(httpResponse -> request.asyncStream(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<E> bean(ParameterizedType type) {
+    return request
+      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
+      .thenApply(httpResponse -> request.asyncBean(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<List<E>> list(ParameterizedType type) {
+    return request
+      .performSendAsync(true, HttpResponse.BodyHandlers.ofByteArray())
+      .thenApply(httpResponse -> request.asyncList(type, httpResponse));
+  }
+
+  @Override
+  public <E> CompletableFuture<Stream<E>> stream(ParameterizedType type) {
     return request
       .performSendAsync(false, HttpResponse.BodyHandlers.ofLines())
       .thenApply(httpResponse -> request.asyncStream(type, httpResponse));

--- a/client/src/main/java/io/avaje/http/client/DHttpCall.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpCall.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -61,6 +62,21 @@ final class DHttpCall implements HttpCallResponse {
 
   @Override
   public <E> HttpCall<Stream<E>> stream(Class<E> type) {
+    return new CallStream<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<E> bean(ParameterizedType type) {
+    return new CallBean<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<List<E>> list(ParameterizedType type) {
+    return new CallList<>(type);
+  }
+
+  @Override
+  public <E> HttpCall<Stream<E>> stream(ParameterizedType type) {
     return new CallStream<>(type);
   }
 
@@ -132,46 +148,85 @@ final class DHttpCall implements HttpCallResponse {
 
   private class CallBean<E> implements HttpCall<E> {
     private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
     CallBean(Class<E> type) {
+      this.isGeneric = false;
       this.type = type;
+      this.genericType = null;
     }
+
+    CallBean(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
     @Override
     public E execute() {
-      return request.bean(type);
+      return isGeneric ? request.bean(genericType) : request.bean(type);
     }
+
     @Override
     public CompletableFuture<E> async() {
-      return request.async().bean(type);
+      return isGeneric ? request.async().bean(genericType) : request.async().bean(type);
     }
   }
 
   private class CallList<E> implements HttpCall<List<E>> {
     private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
     CallList(Class<E> type) {
+      this.isGeneric = false;
       this.type = type;
+      this.genericType = null;
     }
+
+    CallList(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
     @Override
     public List<E> execute() {
-      return request.list(type);
+      return isGeneric ? request.list(genericType) : request.list(type);
     }
+
     @Override
     public CompletableFuture<List<E>> async() {
-      return request.async().list(type);
+      return isGeneric ? request.async().list(genericType) : request.async().list(type);
     }
   }
 
   private class CallStream<E> implements HttpCall<Stream<E>> {
     private final Class<E> type;
+    private final ParameterizedType genericType;
+    private final boolean isGeneric;
+
     CallStream(Class<E> type) {
+      this.isGeneric = false;
       this.type = type;
+      this.genericType = null;
     }
+
+    CallStream(ParameterizedType type) {
+      this.isGeneric = true;
+      this.type = null;
+      this.genericType = type;
+    }
+
     @Override
     public Stream<E> execute() {
-      return request.stream(type);
+      return isGeneric ? request.stream(genericType) : request.stream(type);
     }
+
     @Override
     public CompletableFuture<Stream<E>> async() {
-      return request.async().stream(type);
+      return isGeneric ? request.async().stream(genericType) : request.async().stream(type);
     }
   }
 

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -2,6 +2,7 @@ package io.avaje.http.client;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
@@ -273,12 +274,25 @@ final class DHttpClientContext implements HttpClientContext {
     return bodyAdapter.beanReader(cls);
   }
 
+  <T> BodyReader<T> beanReader(ParameterizedType cls) {
+    return bodyAdapter.beanReader(cls);
+  }
+
   <T> T readBean(Class<T> cls, BodyContent content) {
     return bodyAdapter.beanReader(cls).read(content);
   }
 
   <T> List<T> readList(Class<T> cls, BodyContent content) {
     return bodyAdapter.listReader(cls).read(content);
+  }
+
+  @SuppressWarnings("unchecked")
+  <T> T readBean(ParameterizedType cls, BodyContent content) {
+    return (T) bodyAdapter.beanReader(cls).read(content);
+  }
+
+  <T> List<T> readList(ParameterizedType cls, BodyContent content) {
+    return (List<T>) bodyAdapter.listReader(cls).read(content);
   }
 
   void afterResponse(DHttpClientRequest request) {

--- a/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpAsyncResponse.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -334,4 +335,29 @@ public interface HttpAsyncResponse {
    * @return The CompletableFuture of the response
    */
   <E> CompletableFuture<Stream<E>> stream(Class<E> type);
+
+  /**
+   * Process expecting a bean response body (typically from json content).
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<E> bean(ParameterizedType type);
+
+  /**
+   * Process expecting a list of beans response body (typically from json content).
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<List<E>> list(ParameterizedType type);
+
+  /**
+   * Process response as a stream of beans (x-json-stream).
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The CompletableFuture of the response
+   */
+  <E> CompletableFuture<Stream<E>> stream(ParameterizedType type);
+
 }

--- a/client/src/main/java/io/avaje/http/client/HttpCallResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpCallResponse.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.stream.Stream;
@@ -185,5 +186,29 @@ public interface HttpCallResponse {
    * @return The HttpCall to execute sync or async
    */
   <E> HttpCall<Stream<E>> stream(Class<E> type);
+
+  /**
+   * A bean response to execute async or sync.
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The HttpCall to allow sync or async execution
+   */
+  <E> HttpCall<E> bean(ParameterizedType type);
+
+  /**
+   * Process expecting a list of beans response body (typically from json content).
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The HttpCall to execute sync or async
+   */
+  <E> HttpCall<List<E>> list(ParameterizedType type);
+
+  /**
+   * Process expecting a stream of beans response body (typically from json content).
+   *
+   * @param type The parameterized type to convert the content to
+   * @return The HttpCall to execute sync or async
+   */
+  <E> HttpCall<Stream<E>> stream(ParameterizedType type);
 
 }

--- a/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientResponse.java
@@ -1,6 +1,7 @@
 package io.avaje.http.client;
 
 import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.List;
@@ -85,6 +86,7 @@ public interface HttpClientResponse {
    */
   <T> List<T> list(Class<T> type);
 
+
   /**
    * Return the response as a stream of beans.
    * <p>
@@ -105,6 +107,51 @@ public interface HttpClientResponse {
    * @throws HttpException when the response has error status codes
    */
   <T> Stream<T> stream(Class<T> type);
+
+  /**
+   * Return the response as a single bean.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * @param type The parameterized type of the bean to convert the response content into.
+   * @return The bean the response is converted into.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> T bean(ParameterizedType type);
+
+  /**
+   * Return the response as a list of beans.
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * @param type The parameterized type of the bean to convert the response content into.
+   * @return The list of beans the response is converted into.
+   * @throws HttpException when the response has error status codes
+   */
+  <T> List<T> list(ParameterizedType type);
+
+  /**
+   * Return the response as a stream of beans.
+   * <p>
+   * Typically the response is expected to be {@literal application/x-json-stream}
+   * newline delimited json payload.
+   * <p>
+   * Note that for this stream request the response content is not deemed
+   * 'loggable' by avaje-http-client. This is because the entire response
+   * may not be available at the time of the callback. As such {@link RequestLogger}
+   * will not include response content when logging stream request/response
+   * <p>
+   * If the HTTP statusCode is not in the 2XX range a HttpException is throw which contains
+   * the HttpResponse. This is the cause in the CompletionException.
+   *
+   * @param type The parameterized type of the bean to convert the response content into.
+   * @return The stream of beans from the response
+   * @throws HttpException when the response has error status codes
+   */
+  <T> Stream<T> stream(ParameterizedType type);
+
 
   /**
    * Return the response with check for 200 range status code.

--- a/client/src/main/java/io/avaje/http/client/JsonbBodyAdapter.java
+++ b/client/src/main/java/io/avaje/http/client/JsonbBodyAdapter.java
@@ -1,13 +1,15 @@
 package io.avaje.http.client;
 
-import io.avaje.jsonb.JsonType;
-import io.avaje.jsonb.Jsonb;
-
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+
 /**
- * avaje jsonb BodyAdapter to read and write beans as JSON.
+ * Avaje Jsonb BodyAdapter to read and write beans as JSON.
  *
  * <pre>{@code
  *
@@ -21,9 +23,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class JsonbBodyAdapter implements BodyAdapter {
 
   private final Jsonb jsonb;
-  private final ConcurrentHashMap<Class<?>, BodyWriter<?>> beanWriterCache = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Class<?>, BodyReader<?>> beanReaderCache = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Class<?>, BodyReader<?>> listReaderCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Type, BodyWriter<?>> beanWriterCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Type, BodyReader<?>> beanReaderCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Type, BodyReader<?>> listReaderCache = new ConcurrentHashMap<>();
 
   /**
    * Create passing the Jsonb to use.
@@ -36,7 +38,7 @@ public final class JsonbBodyAdapter implements BodyAdapter {
    * Create with a default Jsonb that allows unknown properties.
    */
   public JsonbBodyAdapter() {
-    this.jsonb = Jsonb.newBuilder().build();
+    this.jsonb = Jsonb.builder().build();
   }
 
   @SuppressWarnings("unchecked")
@@ -49,6 +51,18 @@ public final class JsonbBodyAdapter implements BodyAdapter {
   @Override
   public <T> BodyReader<T> beanReader(Class<T> cls) {
     return (BodyReader<T>) beanReaderCache.computeIfAbsent(cls, aClass -> new JReader<>(jsonb.type(cls)));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> BodyReader<T> beanReader(ParameterizedType cls) {
+    return (BodyReader<T>) beanReaderCache.computeIfAbsent(cls, aClass -> new JReader<>(jsonb.type(cls)));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> BodyReader<List<T>> listReader(ParameterizedType cls) {
+    return (BodyReader<List<T>>) listReaderCache.computeIfAbsent(cls, aClass -> new JReader<>(jsonb.type(cls).list()));
   }
 
   @SuppressWarnings("unchecked")

--- a/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -394,7 +394,7 @@ class HelloControllerTest extends BaseWebTest {
     final HttpResponse<String> hres = request.GET().asString();
 
     assertThat(hres.statusCode()).isEqualTo(404);
-    assertThat(hres.body()).contains("Not found");
+    assertThat(hres.body()).contains("Not Found");
     HttpClientContext.Metrics metrics = clientContext.metrics(true);
     assertThat(metrics.totalCount()).isEqualTo(1);
     assertThat(metrics.errorCount()).isEqualTo(1);


### PR DESCRIPTION
Jsonb now has support for Generics, Why not add it in over here?

- Updates body adapter/httpresponse interfaces with new methods to accept a Java `ParameterizedType`