### PR TITLE
Add HttpClient as a better name than HttpClientContext with deprecation

### DIFF
--- a/client/src/main/java/io/avaje/http/client/DBaseBuilder.java
+++ b/client/src/main/java/io/avaje/http/client/DBaseBuilder.java
@@ -1,0 +1,172 @@
+package io.avaje.http.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.avaje.inject.BeanScope;
+import io.avaje.jsonb.Jsonb;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.ProxySelector;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+abstract class DBaseBuilder {
+
+  java.net.http.HttpClient client;
+  String baseUrl;
+  boolean requestLogging = true;
+  Duration requestTimeout = Duration.ofSeconds(20);
+  BodyAdapter bodyAdapter;
+  RetryHandler retryHandler;
+  AuthTokenProvider authTokenProvider;
+
+  CookieHandler cookieHandler = new CookieManager();
+  java.net.http.HttpClient.Redirect redirect = java.net.http.HttpClient.Redirect.NORMAL;
+  java.net.http.HttpClient.Version version;
+  Executor executor;
+  ProxySelector proxy;
+  SSLContext sslContext;
+  SSLParameters sslParameters;
+  Authenticator authenticator;
+  int priority;
+
+  final List<RequestIntercept> interceptors = new ArrayList<>();
+  final List<RequestListener> listeners = new ArrayList<>();
+
+  void configureFromScope(BeanScope beanScope) {
+    if (bodyAdapter == null) {
+      configureBodyAdapter(beanScope);
+    }
+    if (retryHandler == null) {
+      configureRetryHandler(beanScope);
+    }
+  }
+
+  private void configureRetryHandler(BeanScope beanScope) {
+    beanScope.getOptional(RetryHandler.class)
+      .ifPresent(this::setRetryHandler);
+  }
+
+  private void setRetryHandler(RetryHandler retryHandler) {
+    this.retryHandler = retryHandler;
+  }
+
+  private void configureBodyAdapter(BeanScope beanScope) {
+    Optional<BodyAdapter> body = beanScope.getOptional(BodyAdapter.class);
+    if (body.isPresent()) {
+      bodyAdapter = body.get();
+    } else if (beanScope.contains("io.avaje.jsonb.Jsonb")) {
+      bodyAdapter = new JsonbBodyAdapter(beanScope.get(Jsonb.class));
+    } else if (beanScope.contains("com.fasterxml.jackson.databind.ObjectMapper")) {
+      ObjectMapper objectMapper = beanScope.get(ObjectMapper.class);
+      bodyAdapter = new JacksonBodyAdapter(objectMapper);
+    }
+  }
+
+  private RequestListener buildListener() {
+    if (listeners.isEmpty()) {
+      return null;
+    } else if (listeners.size() == 1) {
+      return listeners.get(0);
+    } else {
+      return new DRequestListeners(listeners);
+    }
+  }
+
+  private RequestIntercept buildIntercept() {
+    if (interceptors.isEmpty()) {
+      return null;
+    } else if (interceptors.size() == 1) {
+      return interceptors.get(0);
+    } else {
+      return new DRequestInterceptors(interceptors);
+    }
+  }
+
+  private java.net.http.HttpClient defaultClient() {
+    final java.net.http.HttpClient.Builder builder = java.net.http.HttpClient.newBuilder()
+      .followRedirects(redirect)
+      .connectTimeout(Duration.ofSeconds(20));
+    if (cookieHandler != null) {
+      builder.cookieHandler(cookieHandler);
+    }
+    if (version != null) {
+      builder.version(version);
+    }
+    if (executor != null) {
+      builder.executor(executor);
+    }
+    if (proxy != null) {
+      builder.proxy(proxy);
+    }
+    if (sslContext != null) {
+      builder.sslContext(sslContext);
+    }
+    if (sslParameters != null) {
+      builder.sslParameters(sslParameters);
+    }
+    if (authenticator != null) {
+      builder.authenticator(authenticator);
+    }
+    if (priority > 0) {
+      builder.priority(priority);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Create a reasonable default BodyAdapter if avaje-jsonb or Jackson are present.
+   */
+  private BodyAdapter defaultBodyAdapter() {
+    try {
+      return detectJsonb() ? new JsonbBodyAdapter()
+        : detectJackson() ? new JacksonBodyAdapter()
+        : null;
+    } catch (IllegalAccessError e) {
+      // not in module path
+      return null;
+    }
+  }
+
+  private boolean detectJsonb() {
+    return detectTypeExists("io.avaje.jsonb.Jsonb");
+  }
+
+  private boolean detectJackson() {
+    return detectTypeExists("com.fasterxml.jackson.databind.ObjectMapper");
+  }
+
+  private boolean detectTypeExists(String className) {
+    try {
+      Class.forName(className);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  DHttpClientContext buildClient() {
+    requireNonNull(baseUrl, "baseUrl is not specified");
+    requireNonNull(requestTimeout, "requestTimeout is not specified");
+    if (client == null) {
+      client = defaultClient();
+    }
+    if (requestLogging) {
+      // register the builtin request/response logging
+      this.listeners.add(new RequestLogger());
+    }
+    if (bodyAdapter == null) {
+      bodyAdapter = defaultBodyAdapter();
+    }
+    return new DHttpClientContext(client, baseUrl, requestTimeout, bodyAdapter, retryHandler, buildListener(), authTokenProvider, buildIntercept());
+  }
+
+}

--- a/client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientBuilder.java
@@ -7,137 +7,136 @@ import javax.net.ssl.SSLParameters;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
-import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.Executor;
 
-final class DHttpClientContextBuilder extends DBaseBuilder implements HttpClientContext.Builder, HttpClientContext.Builder.State {
+final class DHttpClientBuilder extends DBaseBuilder implements HttpClient.Builder, HttpClient.Builder.State {
 
-  DHttpClientContextBuilder() {
+  DHttpClientBuilder() {
   }
 
   @Override
-  public HttpClientContext.Builder client(HttpClient client) {
+  public HttpClient.Builder client(java.net.http.HttpClient client) {
     this.client = client;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder baseUrl(String baseUrl) {
+  public HttpClient.Builder baseUrl(String baseUrl) {
     this.baseUrl = baseUrl;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder requestTimeout(Duration requestTimeout) {
+  public HttpClient.Builder requestTimeout(Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder bodyAdapter(BodyAdapter adapter) {
+  public HttpClient.Builder bodyAdapter(BodyAdapter adapter) {
     this.bodyAdapter = adapter;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder retryHandler(RetryHandler retryHandler) {
+  public HttpClient.Builder retryHandler(RetryHandler retryHandler) {
     this.retryHandler = retryHandler;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder requestLogging(boolean requestLogging) {
+  public HttpClient.Builder requestLogging(boolean requestLogging) {
     this.requestLogging = requestLogging;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder requestListener(RequestListener requestListener) {
+  public HttpClient.Builder requestListener(RequestListener requestListener) {
     this.listeners.add(requestListener);
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder requestIntercept(RequestIntercept requestIntercept) {
+  public HttpClient.Builder requestIntercept(RequestIntercept requestIntercept) {
     this.interceptors.add(requestIntercept);
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder authTokenProvider(AuthTokenProvider authTokenProvider) {
+  public HttpClient.Builder authTokenProvider(AuthTokenProvider authTokenProvider) {
     this.authTokenProvider = authTokenProvider;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder cookieHandler(CookieHandler cookieHandler) {
+  public HttpClient.Builder cookieHandler(CookieHandler cookieHandler) {
     this.cookieHandler = cookieHandler;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder redirect(HttpClient.Redirect redirect) {
+  public HttpClient.Builder redirect(java.net.http.HttpClient.Redirect redirect) {
     this.redirect = redirect;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder version(HttpClient.Version version) {
+  public HttpClient.Builder version(java.net.http.HttpClient.Version version) {
     this.version = version;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder executor(Executor executor) {
+  public HttpClient.Builder executor(Executor executor) {
     this.executor = executor;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder proxy(ProxySelector proxySelector) {
+  public HttpClient.Builder proxy(ProxySelector proxySelector) {
     this.proxy = proxySelector;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder sslContext(SSLContext sslContext) {
+  public HttpClient.Builder sslContext(SSLContext sslContext) {
     this.sslContext = sslContext;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder sslParameters(SSLParameters sslParameters) {
+  public HttpClient.Builder sslParameters(SSLParameters sslParameters) {
     this.sslParameters = sslParameters;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder authenticator(Authenticator authenticator) {
+  public HttpClient.Builder authenticator(Authenticator authenticator) {
     this.authenticator = authenticator;
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder priority(int priority) {
+  public HttpClient.Builder priority(int priority) {
     this.priority = priority;
     return this;
   }
 
   @Override
-  public State state() {
+  public HttpClient.Builder.State state() {
     return this;
   }
 
   @Override
-  public HttpClientContext.Builder configureWith(BeanScope beanScope) {
+  public HttpClient.Builder configureWith(BeanScope beanScope) {
     super.configureFromScope(beanScope);
     return this;
   }
 
   @Override
-  public HttpClientContext build() {
-    return super.buildClient();
+  public HttpClient build() {
+    return buildClient();
   }
 
   @Override
@@ -151,7 +150,7 @@ final class DHttpClientContextBuilder extends DBaseBuilder implements HttpClient
   }
 
   @Override
-  public HttpClient client() {
+  public java.net.http.HttpClient client() {
     return client;
   }
 

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
-final class DHttpClientContext implements HttpClientContext {
+final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
 
   /**
    * HTTP Authorization header.

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -3,7 +3,6 @@ package io.avaje.http.client;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
-import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -24,7 +23,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   static final String AUTHORIZATION = "Authorization";
   private static final String BEARER = "Bearer ";
 
-  private final HttpClient httpClient;
+  private final java.net.http.HttpClient httpClient;
   private final String baseUrl;
   private final Duration requestTimeout;
   private final BodyAdapter bodyAdapter;
@@ -41,7 +40,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   private final LongAdder metricResMicros = new LongAdder();
   private final LongAccumulator metricResMaxMicros = new LongAccumulator(Math::max, 0);
 
-  DHttpClientContext(HttpClient httpClient, String baseUrl, Duration requestTimeout, BodyAdapter bodyAdapter, RetryHandler retryHandler, RequestListener requestListener, AuthTokenProvider authTokenProvider, RequestIntercept intercept) {
+  DHttpClientContext(java.net.http.HttpClient httpClient, String baseUrl, Duration requestTimeout, BodyAdapter bodyAdapter, RetryHandler retryHandler, RequestListener requestListener, AuthTokenProvider authTokenProvider, RequestIntercept intercept) {
     this.httpClient = httpClient;
     this.baseUrl = baseUrl;
     this.requestTimeout = requestTimeout;
@@ -106,17 +105,17 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   }
 
   @Override
-  public HttpClient httpClient() {
+  public java.net.http.HttpClient httpClient() {
     return httpClient;
   }
 
   @Override
-  public Metrics metrics() {
+  public HttpClient.Metrics metrics() {
     return metrics(false);
   }
 
   @Override
-  public Metrics metrics(boolean reset) {
+  public HttpClient.Metrics metrics(boolean reset) {
     if (reset) {
       return new DMetrics(metricResTotal.sumThenReset(), metricResError.sumThenReset(), metricResBytes.sumThenReset(), metricResMicros.sumThenReset(), metricResMaxMicros.getThenReset());
     } else {
@@ -128,7 +127,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
     metricResBytes.add(stringBody);
   }
 
-  static final class DMetrics implements Metrics {
+  static final class DMetrics implements HttpClient.Metrics {
 
     private final long totalCount;
     private final long errorCount;

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContext.java
@@ -95,7 +95,7 @@ final class DHttpClientContext implements HttpClientContext, SpiHttpClient {
   }
 
   @Override
-  public BodyAdapter converters() {
+  public BodyAdapter bodyAdapter() {
     return bodyAdapter;
   }
 

--- a/client/src/main/java/io/avaje/http/client/DHttpClientContextBuilder.java
+++ b/client/src/main/java/io/avaje/http/client/DHttpClientContextBuilder.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Executor;
 
 import static java.util.Objects.requireNonNull;
 
-final class DHttpClientContextBuilder implements HttpClientContext.Builder.State {
+final class DHttpClientContextBuilder implements HttpClientContext.Builder, HttpClientContext.Builder.State {
 
   private HttpClient client;
   private String baseUrl;

--- a/client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -1,0 +1,100 @@
+package io.avaje.http.client;
+
+import java.time.Duration;
+
+/**
+ * The HTTP client context that we use to build and process requests.
+ *
+ * <pre>{@code
+ *
+ *   HttpClient client = HttpClient.builder()
+ *       .baseUrl("http://localhost:8080")
+ *       .bodyAdapter(new JacksonBodyAdapter())
+ *       .build();
+ *
+ *  HelloDto dto = client.request()
+ *       .path("hello")
+ *       .queryParam("name", "Rob")
+ *       .queryParam("say", "Whats up")
+ *       .GET()
+ *       .bean(HelloDto.class);
+ *
+ * }</pre>
+ */
+public interface HttpClient {
+
+  interface Builder {
+
+    /**
+     * The state of the builder with methods to read the set state.
+     */
+    interface State {
+
+      /**
+       * Return the base URL.
+       */
+      String baseUrl();
+
+      /**
+       * Return the body adapter.
+       */
+      BodyAdapter bodyAdapter();
+
+      /**
+       * Return the HttpClient.
+       */
+      java.net.http.HttpClient client();
+
+      /**
+       * Return true if requestLogging is on.
+       */
+      boolean requestLogging();
+
+      /**
+       * Return the request timeout.
+       */
+      Duration requestTimeout();
+
+      /**
+       * Return the retry handler.
+       */
+      RetryHandler retryHandler();
+    }
+  }
+
+  /**
+   * Statistic metrics collected to provide an overview of activity of this client.
+   */
+  interface Metrics {
+
+    /**
+     * Return the total number of responses.
+     */
+    long totalCount();
+
+    /**
+     * Return the total number of error responses (status code >= 300).
+     */
+    long errorCount();
+
+    /**
+     * Return the total response bytes (excludes streaming responses).
+     */
+    long responseBytes();
+
+    /**
+     * Return the total response time in microseconds.
+     */
+    long totalMicros();
+
+    /**
+     * Return the max response time in microseconds (since the last reset).
+     */
+    long maxMicros();
+
+    /**
+     * Return the average response time in microseconds.
+     */
+    long avgMicros();
+  }
+}

--- a/client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -1,6 +1,14 @@
 package io.avaje.http.client;
 
+import io.avaje.inject.BeanScope;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
 import java.time.Duration;
+import java.util.concurrent.Executor;
 
 /**
  * The HTTP client context that we use to build and process requests.
@@ -23,7 +31,265 @@ import java.time.Duration;
  */
 public interface HttpClient {
 
+  /**
+   * Return the builder to config and build the client context.
+   *
+   * <pre>{@code
+   *
+   *   HttpClient client = HttpClient.builder()
+   *       .baseUrl("http://localhost:8080")
+   *       .bodyAdapter(new JacksonBodyAdapter())
+   *       .build();
+   *
+   *  HttpResponse<String> res = client.request()
+   *       .path("hello")
+   *       .GET().asString();
+   *
+   * }</pre>
+   */
+  static Builder builder() {
+    return new DHttpClientBuilder();
+  }
+
+  /**
+   * Return the http client API implementation.
+   *
+   * @param clientInterface A <code>@Client</code> interface with annotated API methods.
+   * @param <T>             The service type.
+   * @return The http client API implementation.
+   */
+  <T> T create(Class<T> clientInterface);
+
+  /**
+   * Create a new request.
+   */
+  HttpClientRequest request();
+
+  /**
+   * Return the body adapter used by the client context.
+   * <p>
+   * This is the body adapter used to convert request and response
+   * bodies to java types. For example using Jackson with JSON payloads.
+   */
+  BodyAdapter converters();
+
+  /**
+   * Return the current aggregate metrics.
+   * <p>
+   * These metrics are collected for all requests sent via this context.
+   */
+  HttpClientContext.Metrics metrics();
+
+  /**
+   * Return the current metrics with the option of resetting the underlying counters.
+   * <p>
+   * These metrics are collected for all requests sent via this context.
+   */
+  HttpClientContext.Metrics metrics(boolean reset);
+
+  /**
+   * Builds the HttpClient.
+   *
+   * <pre>{@code
+   *
+   *   HttpClient client = HttpClient.builder()
+   *       .baseUrl("http://localhost:8080")
+   *       .bodyAdapter(new JacksonBodyAdapter())
+   *       .build();
+   *
+   *  HelloDto dto = client.request()
+   *       .path("hello")
+   *       .queryParam("name", "Rob")
+   *       .queryParam("say", "Whats up")
+   *       .GET()
+   *       .bean(HelloDto.class);
+   *
+   * }</pre>
+   */
   interface Builder {
+
+    /**
+     * Set the base URL to use for requests created from the context.
+     * <p>
+     * Note that the base url can be replaced via {@link HttpClientRequest#url(String)}.
+     */
+    Builder baseUrl(String baseUrl);
+
+    /**
+     * Set the default request timeout.
+     *
+     * @see java.net.http.HttpRequest.Builder#timeout(Duration)
+     */
+    Builder requestTimeout(Duration requestTimeout);
+
+    /**
+     * Set the body adapter to use to convert beans to body content
+     * and response content back to beans.
+     */
+    Builder bodyAdapter(BodyAdapter adapter);
+
+    /**
+     * Set a RetryHandler to use to retry requests.
+     */
+    Builder retryHandler(RetryHandler retryHandler);
+
+    /**
+     * Disable or enable built in request and response logging.
+     * <p>
+     * By default request logging is enabled. Set this to false to stop
+     * the default {@link RequestLogger} being registered to log request
+     * and response headers and bodies etc.
+     * <p>
+     * With logging level set to {@code DEBUG} for
+     * {@code io.avaje.http.client.RequestLogger} the request and response
+     * are logged as a summary with response status and time.
+     * <p>
+     * Set the logging level to {@code TRACE} to include the request
+     * and response headers and body payloads with truncation for large
+     * bodies.
+     *
+     * <h3>Suppression</h3>
+     * <p>
+     * We can also use {@link HttpClientRequest#suppressLogging()} to suppress
+     * logging on specific requests.
+     * <p>
+     * Logging of Authorization headers is suppressed.
+     * {@link AuthTokenProvider} requests are suppressed.
+     *
+     * @param requestLogging Disable/enable the registration of the default logger
+     * @see RequestLogger
+     */
+    Builder requestLogging(boolean requestLogging);
+
+    /**
+     * Add a request listener. Multiple listeners may be added, when
+     * do so they will process events in the order they were added.
+     * <p>
+     * Note that {@link RequestLogger} is an implementation for debug
+     * logging request/response headers and content which is registered
+     * by default depending on {@link #requestLogging(boolean)}.
+     *
+     * @see RequestLogger
+     */
+    Builder requestListener(RequestListener requestListener);
+
+    /**
+     * Add a request interceptor. Multiple interceptors may be added.
+     */
+    Builder requestIntercept(RequestIntercept requestIntercept);
+
+    /**
+     * Add a Authorization token provider.
+     * <p>
+     * When set all requests are expected to use a Authorization Bearer token
+     * unless they are marked via {@link HttpClientRequest#skipAuthToken()}.
+     * <p>
+     * The AuthTokenProvider obtains a new token typically with an expiry. This
+     * is automatically called as needed and the Authorization Bearer header set
+     * on all requests (not marked with skipAuthToken()).
+     */
+    Builder authTokenProvider(AuthTokenProvider authTokenProvider);
+
+    /**
+     * Set the underlying HttpClient to use.
+     * <p>
+     * Used when we wish to control all options of the HttpClient.
+     */
+    Builder client(java.net.http.HttpClient client);
+
+    /**
+     * Specify a cookie handler to use on the HttpClient. This would override the default cookie handler.
+     *
+     * @see java.net.http.HttpClient.Builder#cookieHandler(CookieHandler)
+     */
+    Builder cookieHandler(CookieHandler cookieHandler);
+
+    /**
+     * Specify the redirect policy. Defaults to HttpClient.Redirect.NORMAL.
+     *
+     * @see java.net.http.HttpClient.Builder#followRedirects(java.net.http.HttpClient.Redirect)
+     */
+    Builder redirect(java.net.http.HttpClient.Redirect redirect);
+
+    /**
+     * Specify the HTTP version. Defaults to not set.
+     *
+     * @see java.net.http.HttpClient.Builder#version(java.net.http.HttpClient.Version)
+     */
+    Builder version(java.net.http.HttpClient.Version version);
+
+    /**
+     * Specify the Executor to use for asynchronous tasks.
+     * If not specified a default executor will be used.
+     *
+     * @see java.net.http.HttpClient.Builder#executor(Executor)
+     */
+    Builder executor(Executor executor);
+
+    /**
+     * Set the proxy to the underlying {@link java.net.http.HttpClient}.
+     *
+     * @see java.net.http.HttpClient.Builder#proxy(ProxySelector)
+     */
+    Builder proxy(ProxySelector proxySelector);
+
+    /**
+     * Set the sslContext to the underlying {@link java.net.http.HttpClient}.
+     *
+     * @see java.net.http.HttpClient.Builder#sslContext(SSLContext)
+     */
+    Builder sslContext(SSLContext sslContext);
+
+    /**
+     * Set the sslParameters to the underlying {@link java.net.http.HttpClient}.
+     *
+     * @see java.net.http.HttpClient.Builder#sslParameters(SSLParameters)
+     */
+    Builder sslParameters(SSLParameters sslParameters);
+
+    /**
+     * Set a HttpClient authenticator to the underlying {@link java.net.http.HttpClient}.
+     *
+     * @see java.net.http.HttpClient.Builder#authenticator(Authenticator)
+     */
+    Builder authenticator(Authenticator authenticator);
+
+    /**
+     * Set the priority for HTTP/2 requests to the underlying {@link java.net.http.HttpClient}.
+     *
+     * @see java.net.http.HttpClient.Builder#priority(int)
+     */
+    Builder priority(int priority);
+
+    /**
+     * Configure BodyAdapter and RetryHandler using dependency injection BeanScope.
+     */
+    Builder configureWith(BeanScope beanScope);
+
+    /**
+     * Return the state of the builder.
+     */
+    Builder.State state();
+
+    /**
+     * Build and return the context.
+     *
+     * <pre>{@code
+     *
+     *   HttpClient client = HttpClient.builder()
+     *       .baseUrl("http://localhost:8080")
+     *       .bodyAdapter(new JacksonBodyAdapter())
+     *       .build();
+     *
+     *  HelloDto dto = client.request()
+     *       .path("hello")
+     *       .queryParam("say", "Whats up")
+     *       .GET()
+     *       .bean(HelloDto.class);
+     *
+     * }</pre>
+     */
+    HttpClient build();
 
     /**
      * The state of the builder with methods to read the set state.

--- a/client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -66,12 +66,22 @@ public interface HttpClient {
   HttpClientRequest request();
 
   /**
+   * Deprecated - migrate to {@link #bodyAdapter()}.
+   * <p>
    * Return the body adapter used by the client context.
    * <p>
    * This is the body adapter used to convert request and response
    * bodies to java types. For example using Jackson with JSON payloads.
    */
-  BodyAdapter converters();
+  @Deprecated
+  default BodyAdapter converters() {
+    return bodyAdapter();
+  }
+
+  /**
+   * Return the BodyAdapter that this client is using.
+   */
+  BodyAdapter bodyAdapter();
 
   /**
    * Return the current aggregate metrics.

--- a/client/src/main/java/io/avaje/http/client/HttpClient.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClient.java
@@ -78,14 +78,14 @@ public interface HttpClient {
    * <p>
    * These metrics are collected for all requests sent via this context.
    */
-  HttpClientContext.Metrics metrics();
+  HttpClient.Metrics metrics();
 
   /**
    * Return the current metrics with the option of resetting the underlying counters.
    * <p>
    * These metrics are collected for all requests sent via this context.
    */
-  HttpClientContext.Metrics metrics(boolean reset);
+  HttpClient.Metrics metrics(boolean reset);
 
   /**
    * Builds the HttpClient.
@@ -331,36 +331,7 @@ public interface HttpClient {
   /**
    * Statistic metrics collected to provide an overview of activity of this client.
    */
-  interface Metrics {
+  interface Metrics extends HttpClientContext.Metrics {
 
-    /**
-     * Return the total number of responses.
-     */
-    long totalCount();
-
-    /**
-     * Return the total number of error responses (status code >= 300).
-     */
-    long errorCount();
-
-    /**
-     * Return the total response bytes (excludes streaming responses).
-     */
-    long responseBytes();
-
-    /**
-     * Return the total response time in microseconds.
-     */
-    long totalMicros();
-
-    /**
-     * Return the max response time in microseconds (since the last reset).
-     */
-    long maxMicros();
-
-    /**
-     * Return the average response time in microseconds.
-     */
-    long avgMicros();
   }
 }

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -33,6 +33,8 @@ import java.util.concurrent.Executor;
 public interface HttpClientContext extends io.avaje.http.client.HttpClient {
 
   /**
+   * Deprecated - migrate to {@link io.avaje.http.client.HttpClient#builder()}.
+   * <p>
    * Return the builder to config and build the client context.
    *
    * <pre>{@code
@@ -48,6 +50,7 @@ public interface HttpClientContext extends io.avaje.http.client.HttpClient {
    *
    * }</pre>
    */
+  @Deprecated
   static HttpClientContext.Builder builder() {
     return new DHttpClientContextBuilder();
   }

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -8,7 +8,6 @@ import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
 import java.net.http.HttpClient;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.concurrent.Executor;
 
@@ -31,7 +30,7 @@ import java.util.concurrent.Executor;
  *
  * }</pre>
  */
-public interface HttpClientContext {
+public interface HttpClientContext extends io.avaje.http.client.HttpClient {
 
   /**
    * Return the builder to config and build the client context.
@@ -60,84 +59,6 @@ public interface HttpClientContext {
   static HttpClientContext.Builder newBuilder() {
     return builder();
   }
-
-  /**
-   * Return the http client API implementation.
-   *
-   * @param clientInterface A <code>@Client</code> interface with annotated API methods.
-   * @param <T>             The service type.
-   * @return The http client API implementation.
-   */
-  <T> T create(Class<T> clientInterface);
-
-  /**
-   * Create a new request.
-   */
-  HttpClientRequest request();
-
-  /**
-   * Return a UrlBuilder to use to build an URL taking into
-   * account the base URL.
-   */
-  UrlBuilder url();
-
-  /**
-   * Return the body adapter used by the client context.
-   * <p>
-   * This is the body adapter used to convert request and response
-   * bodies to java types. For example using Jackson with JSON payloads.
-   */
-  BodyAdapter converters();
-
-  /**
-   * Return the underlying http client.
-   */
-  HttpClient httpClient();
-
-  /**
-   * Return the current aggregate metrics.
-   * <p>
-   * These metrics are collected for all requests sent via this context.
-   */
-  Metrics metrics();
-
-  /**
-   * Return the current metrics with the option of resetting the underlying counters.
-   * <p>
-   * These metrics are collected for all requests sent via this context.
-   */
-  Metrics metrics(boolean reset);
-
-  /**
-   * Check the response status code and throw HttpException if the status
-   * code is in the error range.
-   */
-  void checkResponse(HttpResponse<?> response);
-
-  /**
-   * Return the response content taking into account content encoding.
-   *
-   * @param httpResponse The HTTP response to decode the content from
-   * @return The decoded content
-   */
-  BodyContent readContent(HttpResponse<byte[]> httpResponse);
-
-  /**
-   * Decode the response content given the <code>Content-Encoding</code> http header.
-   *
-   * @param httpResponse The HTTP response
-   * @return The decoded content
-   */
-  byte[] decodeContent(HttpResponse<byte[]> httpResponse);
-
-  /**
-   * Decode the body using the given encoding.
-   *
-   * @param encoding The encoding used to decode the content
-   * @param content  The raw content being decoded
-   * @return The decoded content
-   */
-  byte[] decodeContent(String encoding, byte[] content);
 
   /**
    * Builds the HttpClientContext.

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -275,7 +275,35 @@ public interface HttpClientContext extends io.avaje.http.client.HttpClient {
   /**
    * Statistic metrics collected to provide an overview of activity of this client.
    */
-  interface Metrics extends io.avaje.http.client.HttpClient.Metrics {
+  interface Metrics {
+    /**
+     * Return the total number of responses.
+     */
+    long totalCount();
 
+    /**
+     * Return the total number of error responses (status code >= 300).
+     */
+    long errorCount();
+
+    /**
+     * Return the total response bytes (excludes streaming responses).
+     */
+    long responseBytes();
+
+    /**
+     * Return the total response time in microseconds.
+     */
+    long totalMicros();
+
+    /**
+     * Return the max response time in microseconds (since the last reset).
+     */
+    long maxMicros();
+
+    /**
+     * Return the average response time in microseconds.
+     */
+    long avgMicros();
   }
 }

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -12,6 +12,9 @@ import java.time.Duration;
 import java.util.concurrent.Executor;
 
 /**
+ * Deprecated in favor of {@link io.avaje.http.client.HttpClient}.
+ * Migrate to using {@link io.avaje.http.client.HttpClient#builder()}.
+ * <p>
  * The HTTP client context that we use to build and process requests.
  *
  * <pre>{@code
@@ -30,6 +33,7 @@ import java.util.concurrent.Executor;
  *
  * }</pre>
  */
+@Deprecated
 public interface HttpClientContext extends io.avaje.http.client.HttpClient {
 
   /**

--- a/client/src/main/java/io/avaje/http/client/HttpClientContext.java
+++ b/client/src/main/java/io/avaje/http/client/HttpClientContext.java
@@ -346,73 +346,15 @@ public interface HttpClientContext {
     /**
      * The state of the builder with methods to read the set state.
      */
-    interface State extends Builder {
+    interface State extends io.avaje.http.client.HttpClient.Builder.State {
 
-      /**
-       * Return the base URL.
-       */
-      String baseUrl();
-
-      /**
-       * Return the body adapter.
-       */
-      BodyAdapter bodyAdapter();
-
-      /**
-       * Return the HttpClient.
-       */
-      HttpClient client();
-
-      /**
-       * Return true if requestLogging is on.
-       */
-      boolean requestLogging();
-
-      /**
-       * Return the request timeout.
-       */
-      Duration requestTimeout();
-
-      /**
-       * Return the retry handler.
-       */
-      RetryHandler retryHandler();
     }
   }
 
   /**
    * Statistic metrics collected to provide an overview of activity of this client.
    */
-  interface Metrics {
+  interface Metrics extends io.avaje.http.client.HttpClient.Metrics {
 
-    /**
-     * Return the total number of responses.
-     */
-    long totalCount();
-
-    /**
-     * Return the total number of error responses (status code >= 300).
-     */
-    long errorCount();
-
-    /**
-     * Return the total response bytes (excludes streaming responses).
-     */
-    long responseBytes();
-
-    /**
-     * Return the total response time in microseconds.
-     */
-    long totalMicros();
-
-    /**
-     * Return the max response time in microseconds (since the last reset).
-     */
-    long maxMicros();
-
-    /**
-     * Return the average response time in microseconds.
-     */
-    long avgMicros();
   }
 }

--- a/client/src/main/java/io/avaje/http/client/SpiHttpClient.java
+++ b/client/src/main/java/io/avaje/http/client/SpiHttpClient.java
@@ -1,0 +1,53 @@
+package io.avaje.http.client;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+
+/**
+ * Internal Http Client interface.
+ */
+interface SpiHttpClient {
+
+  /**
+   * Return a UrlBuilder to use to build an URL taking into
+   * account the base URL.
+   */
+  UrlBuilder url();
+
+  /**
+   * Return the underlying http client.
+   */
+  HttpClient httpClient();
+
+  /**
+   * Return the response content taking into account content encoding.
+   *
+   * @param httpResponse The HTTP response to decode the content from
+   * @return The decoded content
+   */
+  BodyContent readContent(HttpResponse<byte[]> httpResponse);
+
+  /**
+   * Decode the response content given the <code>Content-Encoding</code> http header.
+   *
+   * @param httpResponse The HTTP response
+   * @return The decoded content
+   */
+  byte[] decodeContent(HttpResponse<byte[]> httpResponse);
+
+  /**
+   * Decode the body using the given encoding.
+   *
+   * @param encoding The encoding used to decode the content
+   * @param content  The raw content being decoded
+   * @return The decoded content
+   */
+  byte[] decodeContent(String encoding, byte[] content);
+
+  /**
+   * Check the response status code and throw HttpException if the status
+   * code is in the error range.
+   */
+  void checkResponse(HttpResponse<?> response);
+
+}

--- a/client/src/test/java/io/avaje/http/client/DHttpClientContextTest.java
+++ b/client/src/test/java/io/avaje/http/client/DHttpClientContextTest.java
@@ -45,15 +45,16 @@ class DHttpClientContextTest {
       .baseUrl("http://localhost")
       .build();
 
+    SpiHttpClient spi = (SpiHttpClient)context;
     // has default client created
-    assertThat(context.httpClient()).isNotNull();
-    assertThat(context.httpClient().version()).isEqualTo(HttpClient.Version.HTTP_2);
-    assertThat(context.httpClient().cookieHandler()).isPresent();
+    assertThat(spi.httpClient()).isNotNull();
+    assertThat(spi.httpClient().version()).isEqualTo(HttpClient.Version.HTTP_2);
+    assertThat(spi.httpClient().cookieHandler()).isPresent();
 
     // has expected url building
-    assertThat(context.url().build()).isEqualTo("http://localhost");
-    assertThat(context.url().path("hello").build()).isEqualTo("http://localhost/hello");
-    assertThat(context.url().queryParam("hello","there").build()).isEqualTo("http://localhost?hello=there");
+    assertThat(spi.url().build()).isEqualTo("http://localhost");
+    assertThat(spi.url().path("hello").build()).isEqualTo("http://localhost/hello");
+    assertThat(spi.url().queryParam("hello","there").build()).isEqualTo("http://localhost?hello=there");
   }
 
   @Test
@@ -66,15 +67,16 @@ class DHttpClientContextTest {
         .redirect(HttpClient.Redirect.ALWAYS)
         .build();
 
+    SpiHttpClient spi = (SpiHttpClient)context;
     // has default client created
-    assertThat(context.httpClient()).isNotNull();
-    assertThat(context.httpClient().version()).isEqualTo(HttpClient.Version.HTTP_2);
-    assertThat(context.httpClient().cookieHandler()).isEmpty();
+    assertThat(spi.httpClient()).isNotNull();
+    assertThat(spi.httpClient().version()).isEqualTo(HttpClient.Version.HTTP_2);
+    assertThat(spi.httpClient().cookieHandler()).isEmpty();
 
     // has expected url building
-    assertThat(context.url().build()).isEqualTo("http://localhost");
-    assertThat(context.url().path("hello").build()).isEqualTo("http://localhost/hello");
-    assertThat(context.url().queryParam("hello","there").build()).isEqualTo("http://localhost?hello=there");
+    assertThat(spi.url().build()).isEqualTo("http://localhost");
+    assertThat(spi.url().path("hello").build()).isEqualTo("http://localhost/hello");
+    assertThat(spi.url().queryParam("hello","there").build()).isEqualTo("http://localhost?hello=there");
   }
 
   @Test

--- a/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
+++ b/client/src/test/java/io/avaje/http/client/HelloControllerTest.java
@@ -1,6 +1,5 @@
 package io.avaje.http.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.webserver.ErrorResponse;
 import org.example.webserver.HelloDto;
@@ -23,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.net.http.HttpClient.Version.*;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/client/src/test/java/org/example/github/httpclient/Simple$HttpClient.java
+++ b/client/src/test/java/org/example/github/httpclient/Simple$HttpClient.java
@@ -58,7 +58,7 @@ public class Simple$HttpClient implements Simple {
         .body(() -> is)
         .GET().handler(HttpResponse.BodyHandlers.ofInputStream());
 
-    context.checkResponse(response);
+    //context.checkResponse(response);
     return response.body();
   }
 


### PR DESCRIPTION
I have convinced myself that `HttpClient` is a better name than `HttpClientContext`. This does mean that it has the same short name as the underlying `java.net.http.HttpClient` but I think that is ok as:

1. We generally don't need to supply JDK HttpClient but instead just it's builder options (so we very rarely hit the short name collision)
2. Other projects use `HttpClient` as their name.

To me it's become really clear that `HttpClientContext` is a pretty bad name so going for this change. This includes deprecation of  `HttpClientContext.builder()` in favor of  `HttpClient.builder()`. We will keep both for some time to allow people to migrate.